### PR TITLE
Correct node id (in NodeInfo) for kube v1.12.X

### DIFF
--- a/deploy/disk/disk-plugin.yaml
+++ b/deploy/disk/disk-plugin.yaml
@@ -45,14 +45,9 @@ spec:
             allowPrivilegeEscalation: true
           image: registry.cn-hangzhou.aliyuncs.com/plugins/csi-diskplugin:***
           args :
-            - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--v=5"
           env:
-            - name: NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix://var/lib/kubelet/plugins/csi-diskplugin/csi.sock
             - name: ACCESS_KEY_ID

--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -76,7 +76,10 @@ func NewDriver(nodeID, endpoint string) *disk {
 	initDriver()
 	tmpdisk := &disk{}
 	tmpdisk.endpoint = endpoint
-
+	if nodeID == "" {
+		nodeID = GetMetaData(INSTANCE_ID)
+		log.Infof("Use node id : %s", nodeID)
+	}
 	csiDriver := csicommon.NewCSIDriver(driverName, version, nodeID)
 	tmpdisk.driver = csiDriver
 

--- a/pkg/disk/nodeserver.go
+++ b/pkg/disk/nodeserver.go
@@ -254,15 +254,6 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
-//NodeGetId is used by controller to get node id
-func (ns *nodeServer) NodeGetId(ctx context.Context, req *csi.NodeGetIdRequest) (*csi.NodeGetIdResponse, error) {
-	id := GetMetaData(INSTANCE_ID)
-	log.Infof("NodeGetId: %s", id)
-	return &csi.NodeGetIdResponse{
-		NodeId: id,
-	}, nil
-}
-
 func (ns *nodeServer) NodeUnstageVolume(
 	ctx context.Context,
 	req *csi.NodeUnstageVolumeRequest) (


### PR DESCRIPTION
Support 1.12.X