### PR TITLE
fix node select policy for kubernetes from scratch

### DIFF
--- a/deploy/disk/disk-attacher.yaml
+++ b/deploy/disk/disk-attacher.yaml
@@ -31,8 +31,8 @@ spec:
       - effect: NoSchedule
         operator: Exists
         key: node.cloudprovider.kubernetes.io/uninitialized
-      nodeSelector:
-         node-role.kubernetes.io/master: ""
+#      nodeSelector:
+#         node-role.kubernetes.io/master: ""
       serviceAccount: alicloud-csi-plugin
       containers:
         - name: csi-attacher

--- a/deploy/disk/disk-provisioner.yaml
+++ b/deploy/disk/disk-provisioner.yaml
@@ -31,8 +31,8 @@ spec:
       - effect: NoSchedule
         operator: Exists
         key: node.cloudprovider.kubernetes.io/uninitialized
-      nodeSelector:
-         node-role.kubernetes.io/master: ""
+#      nodeSelector:
+#         node-role.kubernetes.io/master: ""
       serviceAccount: alicloud-csi-plugin
       hostNetwork: true
       containers:


### PR DESCRIPTION
If the kubernetes cluster is build from scratch ,  like [KFS](https://kfs.ooclab.com/kfs/v1.15/) , need drop this node select policy.